### PR TITLE
Add Windows support

### DIFF
--- a/bin/deft
+++ b/bin/deft
@@ -76,7 +76,9 @@ function writeFile(filePath, response, callback) {
 }
 
 function copyFile(source, destination) {
-  fs.createReadStream(source).pipe(fs.createWriteStream(destination));
+  // Ensure destination directory exists
+  mkdirp.sync(path.dirname(destination));
+  return fs.createReadStream(source).pipe(fs.createWriteStream(destination));
 }
 
 function randomNumber() {
@@ -127,13 +129,6 @@ function describesArchive(files) {
   return keys.length === 1 && keys[0] === 'archive' && typeof files.archive === 'object';
 }
 
-function extractCommand(fileType) {
-  switch (fileType) {
-    case 'zip': return 'unzip';
-    default: throw 'Unrecognized file type: ' + fileType;
-  }
-}
-
 function downloadArchive(dependency, callback) {
   var archive    = deft.getFilesFromDependency(dependency).archive,
       url        = dependency[0],
@@ -157,29 +152,36 @@ function downloadArchive(dependency, callback) {
   response.on('end', function() {
     message.write(' extracting file...');
 
-    var command = [
-      extractCommand(type),
-      fileName,
-      Object.keys(files).join(' '),
-      '-d ' + tempDir
-    ].join(' ');
+    switch (type) {
+      case 'zip':
+        var DecompressZip = require('decompress-zip');
+        var unzipper = new DecompressZip(fileName);
+        unzipper.on('error', callback);
+        unzipper.on('extract', function() {
+          message.end(' Done.');
+          moveFiles();
+        });
+        unzipper.extract({
+          path: tempDir,
+          filter: function(file) {
+            return file.path in files;
+          }
+        });
+        break;
+      default:
+        throw 'Unrecognized file type: ' + type;
+    }
 
-    exec(command, function(err) {
-      if (err) {
-        return callback(err);
-      }
-
-      message.end(' Done.');
-
+    function moveFiles() {
       waitForDirToExist(tempDir, function() {
-        for (var file in files) {
+        async.each(Object.keys(files), function(file, cb) {
           stync.write('Copying ' + file + '...');
-          copyFile(path.join(tempDir, file), getDestinationPath(files[file]));
-        }
-
-        callback();
+          copyFile(path.join(tempDir, file), getDestinationPath(files[file]))
+            .on('error', cb)
+            .on('finish', cb);
+        }, callback);
       });
-    });
+    }
   });
 }
 
@@ -270,17 +272,17 @@ if (commander.outdated) {
       }
     });
   }
-  
+
   if (archives.length > 0) {
     async.eachSeries(archives, downloadArchive, function(err) {
       if (err) {
         console.log('Encountered an error: ' + err);
       }
-  
+
       if (tempFiles.length === 0 && tempDirs.length === 0) {
         return;
       }
-  
+
       var message = stync.begin('Cleaning up archive downloads...');
       tempFiles.forEach(function(file) { fs.unlinkSync(file); });
       tempDirs.forEach(function(dir) { rimraf.sync(dir); });

--- a/deft.js
+++ b/deft.js
@@ -49,6 +49,14 @@ deft.getFiles = function getFiles(files) {
     return deft.filesFromArray(files);
   }
 
+  Object.keys(files).forEach(function(key) {
+    var normalizedKey = path.normalize(key);
+    if (key !== normalizedKey) {
+      files[normalizedKey] = files[key];
+      delete files[key];
+    }
+  });
+
   return files;
 };
 
@@ -65,7 +73,7 @@ deft.getFiles = function getFiles(files) {
  */
 deft.filesFromString = function filesFromString(string) {
   var object = {};
-  object[string] = path.basename(string);
+  object[path.normalize(string)] = path.basename(string);
   return object;
 };
 
@@ -84,7 +92,7 @@ deft.filesFromString = function filesFromString(string) {
 deft.filesFromArray = function filesFromArray(array) {
   var object = {};
   for (var i = 0; i < array.length; ++i) {
-    object[array[i]] = path.basename(array[i]);
+    object[path.normalize(array[i])] = path.basename(array[i]);
   }
   return object;
 };
@@ -127,10 +135,10 @@ deft.getUrl = function getUrl(file, dependency) {
 
 /**
  * Given a dependency, gets the Github API url to list tags of the project.
- * 
+ *
  * @param {!Array.<string>} dependency
  * @return {string}
- * 
+ *
  * @examples
  * deft.getTagsUrl(['lodash/lodash', 'lodash.js']);
  * // => 'https://api.github.com/repos/lodash/lodash/tags'
@@ -153,10 +161,10 @@ deft.getTagsUrl = function getTagsUrl(dependency) {
 
 /**
  * Given a dependency, gets the tag specified by the configuration.
- * 
+ *
  * @param {!Array.<string>} dependency
  * @return {string}
- * 
+ *
  * @examples
  * deft.getWantedTag(['lodash/lodash', 'lodash.js']);
  * // => undefined

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "async": ">= 0.2.9",
     "commander": ">= 2.0.0",
+    "decompress-zip": "0.0.8",
     "mkdirp": ">= 0.3.5",
     "request": "^2.39.0",
     "rimraf": ">= 2.2.5",


### PR DESCRIPTION
Tested this on both linux and windows, because I do have colleagues that work on windows :)

I have removed the use of the unzip binary for a pure node.js module (bower's), it seems to perform just as well.

I also fixed 2 problems :
- if you only had archive dependency, it would fail to create the destination
- wait for copyFile to finish before cleaning up the source
